### PR TITLE
feat: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v5
+      - name: Install, build, and upload your site
+        uses: withastro/action@v5
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+andrewmmc.com


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automatic deployment to GitHub Pages
- Add CNAME file for custom domain (andrewmmc.com)

## Changes
- `.github/workflows/deploy.yml` - GitHub Actions workflow using `withastro/action@v5`
- `public/CNAME` - Custom domain configuration

## Test plan
- [ ] Merge this PR
- [ ] Go to Settings → Pages → Set Source to GitHub Actions
- [ ] Verify site deploys at https://andrewmmc.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/CD-only changes that affect deployment configuration and custom domain setup, with no application runtime or data/security logic changes.
> 
> **Overview**
> Adds a GitHub Actions workflow (`.github/workflows/deploy.yml`) that builds the Astro site on pushes to `master` (and manual runs) and deploys the generated output to GitHub Pages using `actions/deploy-pages`.
> 
> Adds `public/CNAME` to configure the Pages custom domain as `andrewmmc.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41e3e9ed2d8e4f05bad73bdd1355484c25d4c2c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->