### PR TITLE
refactor: migrate to Tailwind CSS v4

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,10 +2,14 @@
 
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
+import tailwind from '@tailwindcss/vite';
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://andrewmmc.com',
   integrations: [mdx(), sitemap()],
+  vite: {
+    plugins: [tailwind()],
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,14 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@tailwindcss/vite": "^4.1.18",
         "@typescript-eslint/eslint-plugin": "^8.55.0",
         "@typescript-eslint/parser": "^8.55.0",
         "eslint": "^9.39.2",
         "eslint-plugin-astro": "^1.6.0",
         "prettier": "^3.8.1",
         "prettier-plugin-astro": "^0.14.1",
+        "tailwindcss": "^4.1.18",
         "typescript-eslint": "^8.55.0"
       }
     },
@@ -1334,11 +1336,54 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",
@@ -1853,6 +1898,278 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
+      "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "enhanced-resolve": "^5.18.3",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.30.2",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
+      "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.18",
+        "@tailwindcss/oxide-darwin-x64": "4.1.18",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.18",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
+      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
+      "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
+      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
+      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
+      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
+      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
+      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
+      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
+      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
+      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
+      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
+      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
+      "integrity": "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.1.18",
+        "@tailwindcss/oxide": "4.1.18",
+        "tailwindcss": "4.1.18"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7"
+      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -3113,6 +3430,20 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -3882,6 +4213,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/h3": {
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
@@ -4378,6 +4716,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -4442,6 +4790,256 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "devOptional": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/locate-path": {
@@ -6885,6 +7483,27 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
+      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tiny-inflate": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@tailwindcss/vite": "^4.1.18",
     "@typescript-eslint/eslint-plugin": "^8.55.0",
     "@typescript-eslint/parser": "^8.55.0",
     "eslint": "^9.39.2",
     "eslint-plugin-astro": "^1.6.0",
     "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1",
+    "tailwindcss": "^4.1.18",
     "typescript-eslint": "^8.55.0"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://andrewmmc.com/sitemap-index.xml

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -2,26 +2,74 @@
 // Import the global.css file here so that it is included on
 // all pages through the use of the <BaseHead /> component.
 import '../styles/global.css';
-import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+import { SITE_TITLE, SITE_DESCRIPTION, SITE_URL, SOCIAL_LINKS } from '../consts';
 
 interface Props {
   title?: string;
   description?: string;
   keywords?: string;
   ogType?: string;
+  articleDate?: string;
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title, description = SITE_DESCRIPTION, keywords, ogType = 'website' } = Astro.props;
+const { title, description = SITE_DESCRIPTION, keywords, ogType = 'website', articleDate } = Astro.props;
 
 const pageTitle = title ? `${title} \u2013 ${SITE_TITLE}` : SITE_TITLE;
+
+// JSON-LD Structured Data
+const personSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: SITE_TITLE,
+  url: SITE_URL,
+  image: new URL('/avatar.jpg', Astro.site).href,
+  jobTitle: 'Software Engineer',
+  sameAs: [
+    `https://github.com/${SOCIAL_LINKS.github}`,
+    `https://linkedin.com/in/${SOCIAL_LINKS.linkedin}`,
+  ],
+};
+
+const websiteSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: SITE_TITLE,
+  url: SITE_URL,
+  description: SITE_DESCRIPTION,
+  author: {
+    '@type': 'Person',
+    name: SITE_TITLE,
+  },
+};
+
+const articleSchema = ogType === 'article' ? {
+  '@context': 'https://schema.org',
+  '@type': 'BlogPosting',
+  headline: title,
+  datePublished: articleDate,
+  author: {
+    '@type': 'Person',
+    name: SITE_TITLE,
+    url: SITE_URL,
+  },
+  publisher: {
+    '@type': 'Person',
+    name: SITE_TITLE,
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': canonicalURL.href,
+  },
+} : null;
 ---
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <meta name="theme-color" content="#ffffff" />
+<meta name="author" content={SITE_TITLE} />
 <link rel="icon" href="/favicon.png" />
 <link rel="icon" href="/favicon.ico" sizes="any" />
 <link rel="sitemap" href="/sitemap-index.xml" />
@@ -56,6 +104,7 @@ const pageTitle = title ? `${title} \u2013 ${SITE_TITLE}` : SITE_TITLE;
 <meta property="og:title" content={pageTitle} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={new URL('/avatar.jpg', Astro.site)} />
+<meta property="og:image:alt" content={`${SITE_TITLE} profile photo`} />
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary" />
@@ -63,3 +112,9 @@ const pageTitle = title ? `${title} \u2013 ${SITE_TITLE}` : SITE_TITLE;
 <meta name="twitter:title" content={pageTitle} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={new URL('/avatar.jpg', Astro.site)} />
+<meta name="twitter:image:alt" content={`${SITE_TITLE} profile photo`} />
+
+<!-- JSON-LD Structured Data -->
+<script type="application/ld+json" set:html={JSON.stringify(websiteSchema)} />
+<script type="application/ld+json" set:html={JSON.stringify(personSchema)} />
+{articleSchema && <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />}

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -21,6 +21,7 @@ const pageTitle = title ? `${title} \u2013 ${SITE_TITLE}` : SITE_TITLE;
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="theme-color" content="#ffffff" />
 <link rel="icon" href="/favicon.png" />
 <link rel="icon" href="/favicon.ico" sizes="any" />
 <link rel="sitemap" href="/sitemap-index.xml" />
@@ -54,9 +55,11 @@ const pageTitle = title ? `${title} \u2013 ${SITE_TITLE}` : SITE_TITLE;
 <meta property="og:url" content={Astro.url} />
 <meta property="og:title" content={pageTitle} />
 <meta property="og:description" content={description} />
+<meta property="og:image" content={new URL('/avatar.jpg', Astro.site)} />
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:url" content={Astro.url} />
 <meta name="twitter:title" content={pageTitle} />
 <meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={new URL('/avatar.jpg', Astro.site)} />

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,10 +4,16 @@ import { SOCIAL_LINKS } from '../consts';
 const year = new Date().getFullYear();
 ---
 
-<footer>
-  <span class="copyright">&copy; {year}</span>
-  <div class="social-links">
-    <a href="/rss.xml" target="_blank" rel="noopener noreferrer" aria-label="RSS">
+<footer
+  class="flex flex-col items-center justify-between flex-nowrap max-w-container mx-auto px-4 pt-8 pb-8 text-gray-700 sm:flex-row sm:pt-12 sm:pb-12"
+>
+  <span class="mb-2 sm:mb-0">&copy; {year}</span>
+  <div class="flex gap-0">
+    <a
+      href="/rss.xml"
+      aria-label="RSS Feed"
+      class="rounded font-semibold inline-flex items-center justify-center transition-all duration-150 relative whitespace-nowrap align-middle leading-tight h-10 min-w-[2.5rem] text-base p-0 text-inherit hover:bg-gray-100 focus:outline-none focus:bg-primary-50/50"
+    >
       <svg
         viewBox="0 0 24 24"
         width="1em"
@@ -17,6 +23,7 @@ const year = new Date().getFullYear();
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"
+        class="text-current"
       >
         <path d="M4 11a9 9 0 0 1 9 9"></path>
         <path d="M4 4a16 16 0 0 1 16 16"></path>
@@ -28,6 +35,7 @@ const year = new Date().getFullYear();
       target="_blank"
       rel="noopener noreferrer"
       aria-label="GitHub"
+      class="rounded font-semibold inline-flex items-center justify-center transition-all duration-150 relative whitespace-nowrap align-middle leading-tight h-10 min-w-[2.5rem] text-base p-0 text-inherit hover:bg-gray-100 focus:outline-none focus:bg-primary-50/50"
     >
       <svg
         viewBox="0 0 24 24"
@@ -38,6 +46,7 @@ const year = new Date().getFullYear();
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"
+        class="text-current"
       >
         <path
           d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"
@@ -49,6 +58,7 @@ const year = new Date().getFullYear();
       target="_blank"
       rel="noopener noreferrer"
       aria-label="LinkedIn"
+      class="rounded font-semibold inline-flex items-center justify-center transition-all duration-150 relative whitespace-nowrap align-middle leading-tight h-10 min-w-[2.5rem] text-base p-0 text-inherit hover:bg-gray-100 focus:outline-none focus:bg-primary-50/50"
     >
       <svg
         viewBox="0 0 24 24"
@@ -59,83 +69,12 @@ const year = new Date().getFullYear();
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"
+        class="text-current"
       >
-        <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"
-        ></path>
+        <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path>
         <rect x="2" y="9" width="4" height="12"></rect>
         <circle cx="4" cy="4" r="2"></circle>
       </svg>
     </a>
   </div>
 </footer>
-
-<style>
-  footer {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: nowrap;
-    max-width: var(--max-width);
-    margin: 0 auto;
-    padding-left: 1rem;
-    padding-right: 1rem;
-    padding-top: 2rem;
-    padding-bottom: 2rem;
-    color: var(--gray-700);
-  }
-
-  @media (min-width: 30em) {
-    footer {
-      flex-direction: row;
-      padding-top: 3rem;
-      padding-bottom: 3rem;
-    }
-  }
-
-  .copyright {
-    margin-bottom: 0.5rem;
-  }
-
-  @media (min-width: 30em) {
-    .copyright {
-      margin-bottom: 0;
-    }
-  }
-
-  .social-links {
-    display: flex;
-    gap: 0;
-  }
-
-  .social-links a {
-    border-radius: 0.25rem;
-    font-weight: 600;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 250ms;
-    position: relative;
-    white-space: nowrap;
-    vertical-align: middle;
-    line-height: 1.2;
-    outline: none;
-    height: 2.5rem;
-    min-width: 2.5rem;
-    font-size: 1rem;
-    padding: 0;
-    color: inherit;
-  }
-
-  .social-links a:hover {
-    background-color: var(--gray-100);
-  }
-
-  .social-links a:focus {
-    box-shadow: var(--focus-ring);
-  }
-
-  .social-links svg {
-    color: currentColor;
-  }
-</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,145 +2,47 @@
 import { SITE_TITLE, SITE_DESCRIPTION, SOCIAL_LINKS } from '../consts';
 ---
 
-<header>
-  <div class="avatar">
-    <a href="/">
-      <img src="/avatar.jpg" alt={SITE_TITLE} width="80" height="80" />
+<header
+  class="max-w-container mx-auto px-4 py-8 flex flex-col justify-between sm:py-12"
+>
+  <div class="self-start pb-2 sm:pb-6">
+    <a
+      href="/"
+      class="transition-all duration-150 ease-out cursor-pointer no-underline hover:no-underline focus:outline-none"
+    >
+      <img src="/avatar.jpg" alt={SITE_TITLE} width="80" height="80" class="rounded-full block" />
     </a>
   </div>
-  <div class="header-content">
-    <h1><a href="/">{SITE_TITLE}</a></h1>
-    <p class="description">{SITE_DESCRIPTION}</p>
-    <nav>
-      <a href="/about"
-        >About <svg viewBox="0 0 24 24" class="chevron"
-          ><path fill="currentColor" d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"></path></svg
-        ></a
+  <div class="flex flex-col items-start justify-center">
+    <h1
+      class="text-xl leading-snug font-medium mb-2 text-gray-800 lg:text-2xl"
+    >
+      <a href="/" class="text-gray-800 transition-all duration-150 ease-out hover:text-primary-600 focus:outline-none focus:bg-primary-50/50 rounded px-2 py-1 -mx-2"
+        >{SITE_TITLE}</a
       >
+    </h1>
+    <p class="font-sans text-gray-600 text-lg mb-4">{SITE_DESCRIPTION}</p>
+    <nav class="flex flex-row" aria-label="Main navigation">
+      <a
+        href="/about"
+        class="transition-all duration-150 ease-out cursor-pointer text-primary-500 mr-8 hover:text-primary-600 focus:outline-none focus:bg-primary-50/50 rounded px-2 py-1 -mx-2"
+      >
+        About
+        <svg viewBox="0 0 24 24" class="w-[1em] h-[1em] text-current inline-block align-middle ml-1 flex-shrink-0"
+          ><path fill="currentColor" d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"></path></svg
+        >
+      </a>
       <a
         href={`https://github.com/${SOCIAL_LINKS.github}`}
         target="_blank"
         rel="noopener noreferrer"
+        class="transition-all duration-150 ease-out cursor-pointer text-primary-500 mr-8 hover:text-primary-600 focus:outline-none focus:bg-primary-50/50 rounded px-2 py-1 -mx-2"
       >
-        GitHub <svg viewBox="0 0 24 24" class="chevron"
+        GitHub
+        <svg viewBox="0 0 24 24" class="w-[1em] h-[1em] text-current inline-block align-middle ml-1 flex-shrink-0"
           ><path fill="currentColor" d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"></path></svg
         >
       </a>
     </nav>
   </div>
 </header>
-
-<style>
-  header {
-    max-width: var(--max-width);
-    margin: 0 auto;
-    padding: 2rem 1rem;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-  }
-
-  @media (min-width: 30em) {
-    header {
-      padding: 3rem 1rem;
-    }
-  }
-
-  .avatar {
-    align-self: flex-start;
-    padding-bottom: 0.5rem;
-  }
-
-  @media (min-width: 30em) {
-    .avatar {
-      padding-bottom: 1.5rem;
-    }
-  }
-
-  .avatar a {
-    transition: all 0.15s ease-out;
-    cursor: pointer;
-    text-decoration: none;
-    outline: none;
-  }
-
-  .avatar a:hover {
-    text-decoration: none;
-  }
-
-  .avatar img {
-    border-radius: 50%;
-    display: block;
-  }
-
-  .avatar a:focus {
-    outline: none;
-    box-shadow: none;
-  }
-
-  .header-content {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-  }
-
-  h1 {
-    font-size: 1.25rem;
-    line-height: 1.25;
-    font-weight: 500;
-    margin-bottom: 0.5rem;
-    color: var(--gray-800);
-  }
-
-  @media (min-width: 48em) {
-    h1 {
-      font-size: 1.5rem;
-    }
-  }
-
-  h1 a {
-    color: var(--gray-800);
-    transition: all 0.15s ease-out;
-  }
-
-  h1 a:hover {
-    text-decoration: none;
-  }
-
-  .description {
-    font-family: var(--font-sans);
-    color: var(--gray-600);
-    font-size: 1.125rem;
-    margin-bottom: 1rem;
-  }
-
-  nav {
-    display: flex;
-    flex-direction: row;
-  }
-
-  nav a {
-    transition: all 0.15s ease-out;
-    cursor: pointer;
-    text-decoration: none;
-    outline: none;
-    color: var(--primary-500);
-    margin-right: 2rem;
-  }
-
-  nav a:hover {
-    text-decoration: none;
-  }
-
-  .chevron {
-    width: 1em;
-    height: 1em;
-    color: currentColor;
-    display: inline-block;
-    vertical-align: middle;
-    margin-left: 0.25rem;
-    flex-shrink: 0;
-    backface-visibility: hidden;
-  }
-</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,19 +19,16 @@ const { title, description, keywords, ogType } = Astro.props;
     <BaseHead title={title} description={description} keywords={keywords} ogType={ogType} />
   </head>
   <body>
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-white focus:text-primary-600 focus:rounded focus:shadow-lg"
+    >
+      Skip to main content
+    </a>
     <Header />
-    <main>
+    <main id="main-content" class="max-w-container mx-auto px-4 w-full">
       <slot />
     </main>
     <Footer />
   </body>
 </html>
-
-<style>
-  main {
-    max-width: var(--max-width);
-    margin: 0 auto;
-    padding: 0 1rem;
-    width: 100%;
-  }
-</style>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -8,7 +8,7 @@ type Props = CollectionEntry<'blog'>['data'];
 const { title, description, pubDate, updatedDate } = Astro.props;
 ---
 
-<BaseLayout title={title} description={description} ogType="article">
+<BaseLayout title={title} description={description} ogType="article" articleDate={pubDate.toISOString()}>
   <article>
     <header class="mb-8">
       <h2 class="text-2xl font-medium text-gray-800 mb-2">{title}</h2>
@@ -23,98 +23,8 @@ const { title, description, pubDate, updatedDate } = Astro.props;
         }
       </div>
     </header>
-    <div class="prose prose-gray max-w-none">
+    <div class="prose">
       <slot />
     </div>
   </article>
 </BaseLayout>
-
-<style>
-  /* Custom prose styles to match original design */
-  .prose {
-    line-height: 1.7;
-    color: #3b3b3b;
-  }
-
-  .prose :global(h1),
-  .prose :global(h2),
-  .prose :global(h3),
-  .prose :global(h4) {
-    margin-top: 1.5rem;
-    margin-bottom: 1rem;
-    font-weight: 500;
-    color: #3b3b3b;
-  }
-
-  .prose :global(h2) {
-    font-size: 1.25rem;
-  }
-
-  .prose :global(h3) {
-    font-size: 1.125rem;
-  }
-
-  .prose :global(h4) {
-    font-size: 1rem;
-  }
-
-  .prose :global(p) {
-    margin-bottom: 1rem;
-  }
-
-  .prose :global(a) {
-    color: #ae995a;
-  }
-
-  .prose :global(a:hover) {
-    color: #8b7a48;
-  }
-
-  .prose :global(ul),
-  .prose :global(ol) {
-    margin-bottom: 1rem;
-    padding-left: 1.5rem;
-  }
-
-  .prose :global(ul) {
-    list-style-type: disc;
-  }
-
-  .prose :global(ol) {
-    list-style-type: decimal;
-  }
-
-  .prose :global(li) {
-    margin-bottom: 0.5rem;
-  }
-
-  .prose :global(blockquote) {
-    margin: 1rem 0;
-    padding: 0 0 0 1rem;
-    border-left: 4px solid #cec29c;
-    color: #494949;
-    font-style: italic;
-  }
-
-  .prose :global(img) {
-    border-radius: 0.25rem;
-    margin: 1rem 0;
-  }
-
-  .prose :global(figure) {
-    text-align: center;
-    margin: 2rem 0;
-  }
-
-  .prose :global(figcaption) {
-    font-size: 0.875rem;
-    color: #939393;
-    margin-top: 1rem;
-  }
-
-  .prose :global(hr) {
-    border: none;
-    border-top: 1px solid #dddddd;
-    margin: 1.5rem 0;
-  }
-</style>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -10,51 +10,30 @@ const { title, description, pubDate, updatedDate } = Astro.props;
 
 <BaseLayout title={title} description={description} ogType="article">
   <article>
-    <header class="article-header">
-      <h2 class="section-heading">{title}</h2>
-      <div class="meta">
+    <header class="mb-8">
+      <h2 class="text-2xl font-medium text-gray-800 mb-2">{title}</h2>
+      <div class="text-sm text-gray-600">
         <FormattedDate date={pubDate} />
         {
           updatedDate && (
-            <span class="updated">
+            <span class="italic ml-2">
               (Updated: <FormattedDate date={updatedDate} />)
             </span>
           )
         }
       </div>
     </header>
-    <div class="prose">
+    <div class="prose prose-gray max-w-none">
       <slot />
     </div>
   </article>
 </BaseLayout>
 
 <style>
-  .article-header {
-    margin-bottom: 2rem;
-  }
-
-  .section-heading {
-    font-size: 1.5rem;
-    font-weight: 500;
-    color: var(--gray-800);
-    margin-bottom: 0.5rem;
-  }
-
-  .meta {
-    font-size: 0.875rem;
-    color: var(--gray-600);
-  }
-
-  .updated {
-    font-style: italic;
-    margin-left: 0.5rem;
-  }
-
-  /* Prose styles for rendered markdown */
+  /* Custom prose styles to match original design */
   .prose {
     line-height: 1.7;
-    color: var(--gray-800);
+    color: #3b3b3b;
   }
 
   .prose :global(h1),
@@ -64,7 +43,7 @@ const { title, description, pubDate, updatedDate } = Astro.props;
     margin-top: 1.5rem;
     margin-bottom: 1rem;
     font-weight: 500;
-    color: var(--gray-800);
+    color: #3b3b3b;
   }
 
   .prose :global(h2) {
@@ -84,18 +63,17 @@ const { title, description, pubDate, updatedDate } = Astro.props;
   }
 
   .prose :global(a) {
-    color: var(--primary-500);
+    color: #ae995a;
   }
 
   .prose :global(a:hover) {
-    color: var(--primary-600);
+    color: #8b7a48;
   }
 
   .prose :global(ul),
   .prose :global(ol) {
     margin-bottom: 1rem;
     padding-left: 1.5rem;
-    list-style: initial;
   }
 
   .prose :global(ul) {
@@ -113,8 +91,8 @@ const { title, description, pubDate, updatedDate } = Astro.props;
   .prose :global(blockquote) {
     margin: 1rem 0;
     padding: 0 0 0 1rem;
-    border-left: 4px solid var(--primary-300);
-    color: var(--gray-700);
+    border-left: 4px solid #cec29c;
+    color: #494949;
     font-style: italic;
   }
 
@@ -130,13 +108,13 @@ const { title, description, pubDate, updatedDate } = Astro.props;
 
   .prose :global(figcaption) {
     font-size: 0.875rem;
-    color: var(--gray-500);
+    color: #939393;
     margin-top: 1rem;
   }
 
   .prose :global(hr) {
     border: none;
-    border-top: 1px solid var(--gray-200);
+    border-top: 1px solid #dddddd;
     margin: 1.5rem 0;
   }
 </style>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,32 +3,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="404 Not Found">
-  <h1 class="heading">404 Not Found</h1>
-  <p class="message">
+  <h1 class="text-lg font-medium mb-2">404 Not Found</h1>
+  <p class="my-8 leading-relaxed text-gray-600">
     The page you requested cannot be found. The URL may be misspelled or the page you're looking for
     is no longer available.
   </p>
-  <a href="/" class="back-link">&lsaquo; Back Home</a>
+  <a href="/" class="text-primary-500 hover:text-primary-600">&lsaquo; Back Home</a>
 </BaseLayout>
-
-<style>
-  .heading {
-    font-size: 1.125rem;
-    font-weight: 500;
-    margin-bottom: 0.5rem;
-  }
-
-  .message {
-    margin: 2rem 0;
-    line-height: 1.7;
-    color: var(--gray-600);
-  }
-
-  .back-link {
-    color: var(--primary-500);
-  }
-
-  .back-link:hover {
-    color: var(--primary-600);
-  }
-</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -8,71 +8,64 @@ const { Content } = await render(about);
 
 <BaseLayout title={about.data.title} description={about.data.description}>
   <article>
-    <h2 class="section-heading">{about.data.title}</h2>
-    <div class="prose">
+    <h2 class="text-xs font-bold text-gray-400 uppercase tracking-wide mb-4">
+      {about.data.title}
+    </h2>
+    <div class="prose-custom">
       <Content />
     </div>
   </article>
 </BaseLayout>
 
 <style>
-  .section-heading {
-    font-size: 0.75rem;
-    font-weight: 700;
-    color: var(--gray-400);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin-bottom: 1rem;
-  }
-
-  .prose {
+  .prose-custom {
     line-height: 1.7;
-    color: var(--gray-800);
+    color: #3b3b3b;
   }
 
-  .prose :global(p) {
+  .prose-custom :global(p) {
     margin-bottom: 1rem;
   }
 
-  .prose :global(a) {
-    color: var(--primary-500);
+  .prose-custom :global(a) {
+    color: #ae995a;
   }
 
-  .prose :global(a:hover) {
-    color: var(--primary-600);
+  .prose-custom :global(a:hover) {
+    color: #8b7a48;
   }
 
-  .prose :global(strong) {
+  .prose-custom :global(strong) {
     font-weight: 600;
   }
 
-  .prose :global(h2) {
+  .prose-custom :global(h2) {
     font-size: 1.25rem;
     font-weight: 600;
-    color: var(--gray-800);
+    color: #3b3b3b;
     margin-top: 2rem;
     margin-bottom: 1rem;
   }
 
-  .prose :global(h3) {
+  .prose-custom :global(h3) {
     font-size: 1rem;
     font-weight: 600;
-    color: var(--gray-700);
+    color: #494949;
     margin-top: 1.5rem;
     margin-bottom: 0.5rem;
   }
 
-  .prose :global(ul) {
+  .prose-custom :global(ul) {
     list-style: disc;
     padding-left: 1.5rem;
     margin-bottom: 1rem;
   }
 
-  .prose :global(li) {
+  .prose-custom :global(li) {
     margin-bottom: 0.5rem;
   }
 
-  .prose :global(img) {
+  .prose-custom :global(img) {
     width: 100%;
     height: auto;
     margin-bottom: 1.5rem;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -11,63 +11,8 @@ const { Content } = await render(about);
     <h2 class="text-xs font-bold text-gray-400 uppercase tracking-wide mb-4">
       {about.data.title}
     </h2>
-    <div class="prose-custom">
+    <div class="prose">
       <Content />
     </div>
   </article>
 </BaseLayout>
-
-<style>
-  .prose-custom {
-    line-height: 1.7;
-    color: #3b3b3b;
-  }
-
-  .prose-custom :global(p) {
-    margin-bottom: 1rem;
-  }
-
-  .prose-custom :global(a) {
-    color: #ae995a;
-  }
-
-  .prose-custom :global(a:hover) {
-    color: #8b7a48;
-  }
-
-  .prose-custom :global(strong) {
-    font-weight: 600;
-  }
-
-  .prose-custom :global(h2) {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: #3b3b3b;
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-  }
-
-  .prose-custom :global(h3) {
-    font-size: 1rem;
-    font-weight: 600;
-    color: #494949;
-    margin-top: 1.5rem;
-    margin-bottom: 0.5rem;
-  }
-
-  .prose-custom :global(ul) {
-    list-style: disc;
-    padding-left: 1.5rem;
-    margin-bottom: 1rem;
-  }
-
-  .prose-custom :global(li) {
-    margin-bottom: 0.5rem;
-  }
-
-  .prose-custom :global(img) {
-    width: 100%;
-    height: auto;
-    margin-bottom: 1.5rem;
-  }
-</style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -9,18 +9,23 @@ const posts = (await getCollection('blog'))
 ---
 
 <BaseLayout title="Blog">
-  <section class="post-list">
-    <h2 class="section-heading">All posts</h2>
-    <ul>
+  <section>
+    <h2 class="text-base leading-tight font-medium text-gray-400 uppercase mb-4">All posts</h2>
+    <ul class="list-none">
       {
         posts.map((post) => (
-          <li>
-            <div class="post-item">
-              <div class="post-date">
+          <li class="mb-3">
+            <div class="flex flex-col text-gray-600 text-sm">
+              <div class="text-gray-600 text-sm mb-1">
                 <FormattedDate date={post.data.pubDate} />
               </div>
-              <h3>
-                <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+              <h3 class="text-lg leading-tight font-medium text-gray-800 mb-2">
+                <a
+                  href={`/blog/${post.id}/`}
+                  class="text-gray-800 transition-all duration-150 ease-out hover:text-gray-800 hover:no-underline"
+                >
+                  {post.data.title}
+                </a>
               </h3>
             </div>
           </li>
@@ -29,54 +34,3 @@ const posts = (await getCollection('blog'))
     </ul>
   </section>
 </BaseLayout>
-
-<style>
-  .section-heading {
-    font-size: 1rem;
-    line-height: 1.25;
-    font-weight: 500;
-    color: var(--gray-400);
-    text-transform: uppercase;
-    margin-bottom: 1rem;
-  }
-
-  ul {
-    list-style-type: none;
-    list-style-position: inside;
-  }
-
-  li {
-    margin-bottom: 0.75rem;
-  }
-
-  .post-item {
-    display: flex;
-    flex-direction: column;
-    color: var(--gray-600);
-    font-size: 0.875rem;
-  }
-
-  .post-date {
-    color: var(--gray-600);
-    font-size: 0.875rem;
-    margin-bottom: 0.25rem;
-  }
-
-  h3 {
-    font-size: 1.25rem;
-    line-height: 1.25;
-    font-weight: 500;
-    color: var(--gray-800);
-    margin-bottom: 0.5rem;
-  }
-
-  h3 a {
-    color: var(--gray-800);
-    transition: all 0.15s ease-out;
-  }
-
-  h3 a:hover {
-    color: var(--gray-800);
-    text-decoration: none;
-  }
-</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,18 +9,23 @@ const posts = (await getCollection('blog'))
 ---
 
 <BaseLayout>
-  <section class="post-list">
-    <h2 class="section-heading">Blog posts</h2>
-    <ul>
+  <section>
+    <h2 class="text-base leading-tight font-medium text-gray-400 uppercase mb-4">Blog posts</h2>
+    <ul class="list-none">
       {
         posts.map((post) => (
-          <li>
-            <div class="post-item">
-              <div class="post-date">
+          <li class="mb-3">
+            <div class="flex flex-col text-gray-600 text-sm">
+              <div class="text-gray-600 text-sm mb-1">
                 <FormattedDate date={post.data.pubDate} />
               </div>
-              <h3>
-                <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+              <h3 class="text-lg leading-tight font-medium text-gray-800 mb-2">
+                <a
+                  href={`/blog/${post.id}/`}
+                  class="text-gray-800 transition-all duration-150 ease-out hover:text-gray-800 hover:no-underline"
+                >
+                  {post.data.title}
+                </a>
               </h3>
             </div>
           </li>
@@ -29,54 +34,3 @@ const posts = (await getCollection('blog'))
     </ul>
   </section>
 </BaseLayout>
-
-<style>
-  .section-heading {
-    font-size: 1rem;
-    line-height: 1.25;
-    font-weight: 500;
-    color: var(--gray-400);
-    text-transform: uppercase;
-    margin-bottom: 1rem;
-  }
-
-  ul {
-    list-style-type: none;
-    list-style-position: inside;
-  }
-
-  li {
-    margin-bottom: 0.75rem;
-  }
-
-  .post-item {
-    display: flex;
-    flex-direction: column;
-    color: var(--gray-600);
-    font-size: 0.875rem;
-  }
-
-  .post-date {
-    color: var(--gray-600);
-    font-size: 0.875rem;
-    margin-bottom: 0.25rem;
-  }
-
-  h3 {
-    font-size: 1.25rem;
-    line-height: 1.25;
-    font-weight: 500;
-    color: var(--gray-800);
-    margin-bottom: 0.5rem;
-  }
-
-  h3 a {
-    color: var(--gray-800);
-    transition: all 0.15s ease-out;
-  }
-
-  h3 a:hover {
-    color: var(--gray-800);
-    text-decoration: none;
-  }
-</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -154,3 +154,102 @@
     clip: rect(0, 0, 0, 0);
   }
 }
+
+/* Prose styles for rendered markdown content */
+@layer components {
+  .prose {
+    line-height: 1.7;
+    color: #3b3b3b;
+  }
+
+  .prose :global(h1),
+  .prose :global(h2),
+  .prose :global(h3),
+  .prose :global(h4) {
+    margin-top: 1.5rem;
+    margin-bottom: 1rem;
+    font-weight: 500;
+    color: #3b3b3b;
+  }
+
+  .prose :global(h2) {
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  .prose :global(h3) {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #494949;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .prose :global(h4) {
+    font-size: 1rem;
+  }
+
+  .prose :global(p) {
+    margin-bottom: 1rem;
+  }
+
+  .prose :global(a) {
+    color: #ae995a;
+  }
+
+  .prose :global(a:hover) {
+    color: #8b7a48;
+  }
+
+  .prose :global(strong) {
+    font-weight: 600;
+  }
+
+  .prose :global(ul),
+  .prose :global(ol) {
+    margin-bottom: 1rem;
+    padding-left: 1.5rem;
+  }
+
+  .prose :global(ul) {
+    list-style-type: disc;
+  }
+
+  .prose :global(ol) {
+    list-style-type: decimal;
+  }
+
+  .prose :global(li) {
+    margin-bottom: 0.5rem;
+  }
+
+  .prose :global(blockquote) {
+    margin: 1rem 0;
+    padding: 0 0 0 1rem;
+    border-left: 4px solid #cec29c;
+    color: #494949;
+    font-style: italic;
+  }
+
+  .prose :global(img) {
+    border-radius: 0.25rem;
+    margin: 1rem 0;
+  }
+
+  .prose :global(figure) {
+    text-align: center;
+    margin: 2rem 0;
+  }
+
+  .prose :global(figcaption) {
+    font-size: 0.875rem;
+    color: #939393;
+    margin-top: 1rem;
+  }
+
+  .prose :global(hr) {
+    border: none;
+    border-top: 1px solid #dddddd;
+    margin: 1.5rem 0;
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,225 +1,156 @@
-/* Global styles with design tokens matching original Gatsby theme */
+@import 'tailwindcss';
 
-:root {
+/* Custom theme configuration for Tailwind v4 */
+@theme {
   /* Primary (gold/brown) palette */
-  --primary-50: #efebde;
-  --primary-100: #efebde;
-  --primary-200: #dfd6bd;
-  --primary-300: #cec29c;
-  --primary-400: #bead7b;
-  --primary-500: #ae995a;
-  --primary-600: #8b7a48;
-  --primary-700: #685c36;
-  --primary-800: #463d24;
-  --primary-900: #231f12;
+  --color-primary-50: #efebde;
+  --color-primary-100: #efebde;
+  --color-primary-200: #dfd6bd;
+  --color-primary-300: #cec29c;
+  --color-primary-400: #bead7b;
+  --color-primary-500: #ae995a;
+  --color-primary-600: #8b7a48;
+  --color-primary-700: #685c36;
+  --color-primary-800: #463d24;
+  --color-primary-900: #231f12;
 
   /* Gray palette */
-  --gray-50: #f7f7f7;
-  --gray-100: #f5f5f5;
-  --gray-200: #dddddd;
-  --gray-300: #c4c4c4;
-  --gray-400: #acacac;
-  --gray-500: #939393;
-  --gray-600: #7b7b7b;
-  --gray-700: #494949;
-  --gray-800: #3b3b3b;
-  --gray-900: #2c2c2c;
+  --color-gray-50: #f7f7f7;
+  --color-gray-100: #f5f5f5;
+  --color-gray-200: #dddddd;
+  --color-gray-300: #c4c4c4;
+  --color-gray-400: #acacac;
+  --color-gray-500: #939393;
+  --color-gray-600: #7b7b7b;
+  --color-gray-700: #494949;
+  --color-gray-800: #3b3b3b;
+  --color-gray-900: #2c2c2c;
 
-  /* Semantic tokens */
-  --color-text: var(--gray-800);
-  --color-text-secondary: var(--gray-600);
-  --color-text-muted: var(--gray-400);
-  --color-link: var(--primary-500);
-  --color-link-hover: var(--primary-600);
-  --color-bg: #ffffff;
-  --color-border: var(--gray-200);
-
-  /* Layout */
-  --font-sans:
-    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif,
+  /* Font families */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif,
     'Apple Color Emoji', 'Segoe UI Emoji';
-  --max-width: 48rem;
-  --focus-ring: 0 0 0 2px rgba(179, 179, 179, 0.4);
+  --font-mono: 'SF Mono', SFMono-Regular, ui-monospace, 'DejaVu Sans Mono', Menlo, Consolas,
+    monospace;
+
+  /* Custom max-width */
+  --max-width-container: 48rem;
 }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
+/* Base layer styles */
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  html {
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  body {
+    @apply font-sans m-0 p-0 text-gray-800 bg-white min-h-screen text-base leading-relaxed break-words;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply m-0 text-gray-800 leading-tight font-medium tracking-tight;
+  }
+
+  h1 {
+    @apply text-xl;
+  }
+
+  h2 {
+    @apply text-lg;
+  }
+
+  h3 {
+    @apply text-lg;
+  }
+
+  h4 {
+    @apply text-base;
+  }
+
+  a {
+    @apply text-primary-500 no-underline transition-all duration-150 ease-out;
+  }
+
+  a:hover {
+    @apply text-primary-600;
+  }
+
+  a:focus {
+    @apply outline-none bg-primary-50/50 rounded px-2 py-1 -mx-2;
+  }
+
+  p {
+    @apply m-0;
+  }
+
+  ul,
+  ol {
+    @apply m-0 p-0 list-none;
+  }
+
+  img {
+    @apply max-w-full h-auto block;
+  }
+
+  textarea,
+  input {
+    @apply font-sans text-base;
+  }
+
+  code {
+    @apply font-mono py-0.5 px-1.5 bg-gray-100 border border-gray-200 rounded text-sm;
+    font-size: 0.875em;
+  }
+
+  pre {
+    @apply p-4 border border-gray-200 rounded overflow-x-auto break-words text-sm leading-relaxed;
+    white-space: pre-wrap;
+  }
+
+  pre code {
+    @apply p-0 bg-transparent border-none;
+  }
+
+  blockquote {
+    @apply my-4 pl-4 border-l-4 border-primary-300 text-gray-700 italic;
+  }
+
+  hr {
+    @apply border-none border-t border-gray-200 my-6;
+  }
+
+  table {
+    @apply w-full border border-gray-200 rounded-lg overflow-hidden border-collapse text-sm;
+  }
+
+  th {
+    @apply px-3 py-3 border-b border-gray-200 bg-gray-50 text-left font-medium uppercase tracking-wide text-gray-600;
+  }
+
+  td {
+    @apply px-3 py-3 border-b border-gray-100;
+  }
+
+  tr:last-child td {
+    @apply border-b-0;
+  }
 }
 
-html {
-  line-height: 1.5;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-body {
-  font-family: var(--font-sans);
-  margin: 0;
-  padding: 0;
-  color: var(--color-text);
-  background-color: var(--color-bg);
-  min-height: 100vh;
-  font-size: 1rem;
-  line-height: 1.7;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-}
-
-/* Headings */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  margin: 0;
-  color: var(--gray-800);
-  line-height: 1.2;
-  font-weight: 500;
-  letter-spacing: -0.025em;
-}
-
-h1 {
-  font-size: 1.5rem;
-}
-
-h2 {
-  font-size: 1.25rem;
-}
-
-h3 {
-  font-size: 1.125rem;
-}
-
-h4 {
-  font-size: 1rem;
-}
-
-/* Links */
-a {
-  color: var(--color-link);
-  text-decoration: none;
-}
-
-a:hover {
-  color: var(--color-link-hover);
-}
-
-a:focus {
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
-p {
-  margin: 0;
-}
-
-ul,
-ol {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
-
-/* Form elements */
-textarea,
-input {
-  font-family: inherit;
-  font-size: 1rem;
-}
-
-/* Code */
-code {
-  font-family:
-    'SF Mono', SFMono-Regular, ui-monospace, 'DejaVu Sans Mono', Menlo, Consolas, monospace;
-  padding: 0.125rem 0.375rem;
-  background-color: var(--gray-100);
-  border: 1px solid var(--gray-200);
-  border-radius: 0.25rem;
-  font-size: 0.875em;
-}
-
-pre {
-  padding: 1rem;
-  border: 1px solid var(--gray-200);
-  border-radius: 0.25rem;
-  overflow-x: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-size: 0.875rem;
-  line-height: 1.5;
-}
-
-pre code {
-  padding: 0;
-  background: none;
-  border: none;
-  font-size: inherit;
-}
-
-/* Blockquote */
-blockquote {
-  margin: 1rem 0;
-  padding: 0 0 0 1rem;
-  border-left: 4px solid var(--primary-300);
-  color: var(--gray-700);
-  font-style: italic;
-}
-
-/* Horizontal rule */
-hr {
-  border: none;
-  border-top: 1px solid var(--gray-200);
-  margin: 1.5rem 0;
-}
-
-/* Table */
-table {
-  width: 100%;
-  border: 1px solid var(--gray-200);
-  border-radius: 0.5rem;
-  overflow: hidden;
-  border-collapse: collapse;
-  font-size: 0.875rem;
-}
-
-th {
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--gray-200);
-  background-color: var(--gray-50);
-  text-align: left;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--gray-600);
-}
-
-td {
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--gray-100);
-}
-
-tr:last-child td {
-  border-bottom: none;
-}
-
-/* Screen reader only utility */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
+@layer utilities {
+  .sr-only {
+    @apply absolute w-px h-px p-0 -m-px overflow-hidden whitespace-nowrap border-0;
+    clip: rect(0, 0, 0, 0);
+  }
 }


### PR DESCRIPTION
## Summary
- Migrate from CSS custom properties to Tailwind CSS v4 with `@tailwindcss/vite` plugin
- Add JSON-LD structured data (Person, WebSite, BlogPosting schemas) for better SEO
- Add robots.txt and improve meta tags (author, og:image:alt, twitter:image:alt)
- Add skip-to-content link for accessibility
- Consolidate prose styles into global.css

## Test plan
- [ ] Run `npm run build` - should complete without errors
- [ ] Run `npm run lint` - should pass
- [ ] Preview site and verify styling matches original
- [ ] Check JSON-LD with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Verify focus styles work correctly on keyboard navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewires the styling system and updates many templates; regressions are most likely in visual layout, Tailwind build integration, and SEO markup correctness.
> 
> **Overview**
> Migrates site styling from component-scoped CSS/custom properties to **Tailwind CSS v4**, adding `@tailwindcss/vite` + `tailwindcss`, importing Tailwind in `global.css`, and replacing per-component `<style>` blocks with utility classes (plus consolidated `.prose` styles).
> 
> Improves SEO by adding `robots.txt`, richer meta tags (author/theme color, OG/Twitter images + alt text), and JSON-LD schemas (WebSite/Person and BlogPosting for articles via a new `articleDate` prop wired from `BlogPost.astro`). Also adds a *skip-to-content* link and `main` anchor for better keyboard accessibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 734942a8a42d65dc704ff688464de247f7db2a32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->