### PR TITLE
docs: add cursor cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,3 +168,11 @@ Use relative paths with `../` — no path aliases are configured.
 | `src/styles/global.css` | Design tokens and global styles           |
 | `src/layouts/BaseLayout.astro` | Main page layout wrapper            |
 | `src/components/BaseHead.astro` | HTML `<head>` with meta tags       |
+
+## Cursor Cloud specific instructions
+
+- **Node.js**: The VM uses nvm. Node.js v22 (LTS) is installed as the default. Run commands via `bash -l -c 'cd /workspace && <cmd>'` or ensure nvm is loaded in your shell to pick up the correct Node version.
+- **Dev server**: `npm run dev` starts on `0.0.0.0:4321`. No external services or environment variables are needed.
+- **Pre-commit hooks**: Husky runs `npm run lint`, `npm run format:check`, and `npm run typecheck` on pre-commit. Run these before committing to avoid hook failures.
+- **Tests**: Vitest is configured (`npm run test`). There are 4 pre-existing test failures related to the `back-from-wwdc19` post (uses multi-language `.md` files instead of `index.md`) and the `/blog` route being a redirect. These are not regressions.
+- **No secrets or external services required**: This is a fully static site with no databases, APIs, or authentication.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6098,6 +6098,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6118,6 +6119,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6138,6 +6140,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6158,6 +6161,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6178,6 +6182,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6198,6 +6203,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6218,6 +6224,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6238,6 +6245,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6258,6 +6266,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6278,6 +6287,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6298,6 +6308,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with environment-specific notes for Cloud Agent development sessions:

- Node.js version management via nvm (v22 LTS default)
- Dev server startup details (port 4321, no external deps)
- Pre-commit hook requirements (lint, format, typecheck)
- Pre-existing test failures context (4 known failures)
- Confirmation that no secrets or external services are required

**Verified working:**
- `npm run lint` — passes
- `npm run format:check` — pre-existing issues in 3 files (not introduced by this change)
- `npm run typecheck` — 0 errors, 6 hints
- `npm run build` — 23 pages built successfully
- `npm run dev` — dev server starts on port 4321
- `npm run test` — 68/72 tests pass (4 pre-existing failures)

[astro_blog_demo.mp4](https://cursor.com/agents/bc-baad251d-0abd-4935-af82-db9d8271e64c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_blog_demo.mp4)
[Homepage](https://cursor.com/agents/bc-baad251d-0abd-4935-af82-db9d8271e64c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baad251d-0abd-4935-af82-db9d8271e64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baad251d-0abd-4935-af82-db9d8271e64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

